### PR TITLE
Add option.controller supporting absolute path

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,22 +19,25 @@ function joinParam (url, param) {
 
 /**
  * Main function to initialize routers of a Express app.
- * 
+ *
  * @param  {Object} paths (optional) For configure relative paths of
  *                        controllers rather than defaults.
  */
 module.exports = function (options = {}) {
 	var middleware = express.Router();
-	var ctrlDir = path.join(path.dirname(module.parent.filename), options.controllers || 'controllers');
+	var optionControllers = options.controllers || 'controllers';
+	var ctrlDir = path.isAbsolute(optionControllers) ?
+		optionControllers :
+    path.join(path.dirname(module.parent.filename), optionControllers);
 	var keyRE = new RegExp('(' + methods.join('|') + ')(?:\\s+((?:\\/(.+)\\/)|([^\\/].*[^\\/])))?', 'i');
 	var globOptions = options.glob || {};
-	
+
 	glob.sync(ctrlDir + "/**/*.js", globOptions).forEach(function (file) {
 		file = file.replace(/\.[^.]*$/, '');
 
 		var instance = require(file);
 		var url = file.replace(ctrlDir, '').replace(/\/index$/, '/');
-		
+
 		Object.keys(instance).forEach(function (key) {
 			if (key === 'filters') {
 				return;

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -1,6 +1,6 @@
 var express = require('express');
 var rainbow = require('../../');
-
+var path = require('path');
 
 
 var app = express();
@@ -13,6 +13,10 @@ app.use('/api', rainbow({
 			'**.spec.js'
 		]
 	}
+}));
+
+app.use('/api/abs', rainbow({
+  controllers: path.join(__dirname, 'controllers'),
 }));
 
 var server;

--- a/test/test.js
+++ b/test/test.js
@@ -108,5 +108,14 @@ describe('ignored controller files', function () {
 			assert.equal(http.response.status, 404);
 		}).then(done);
 	});
+});
 
+describe('option controllers as absolute path', function () {
+	it('GET /abs/all.filters method should get the value', function (done) {
+		request.get('/abs/all.filters').then(function (res) {
+			assert.equal(res.status, 200);
+		}).catch(function (http) {
+			console.error(http.response.status);
+		}).then(done);
+	});
 });


### PR DESCRIPTION
Add option.controller supporting absolute path.

In case for the test framework such as `jest` hijacking the `module.parent.filename` that can lead to the rainbow can not find the controllers.